### PR TITLE
use environment variables for the request for logs

### DIFF
--- a/GetJobStatus/run.ps1
+++ b/GetJobStatus/run.ps1
@@ -5,7 +5,7 @@ param($Request, $TriggerMetadata)
 $JobId = $Request.Params.JobId
 
 $JobStatus = Get-AzContainerGroup -ResourceGroupName $env:ResourceGroupName -Name $JobId
-$JobLogs = Get-AzContainerInstanceLog -ResourceGroupName powershell-func-aci -ContainerGroupName $JobId
+$JobLogs = Get-AzContainerInstanceLog -ResourceGroupName $env:ResourceGroupName -ContainerGroupName $JobId
 
 If ($JobStatus.State -eq "Succeeded") {
     $StatusCode = [HttpStatusCode]::OK


### PR DESCRIPTION
Shouldn't the call to retrieve the container logs also use the resource group name via the environment variable?